### PR TITLE
Remove login cmd from GAE deploy

### DIFF
--- a/.github/workflows/gae.yaml
+++ b/.github/workflows/gae.yaml
@@ -40,10 +40,6 @@ jobs:
       run: |
         node node-server/scripts/add-secrets.js
 
-    - name: gcloud login
-      run: |
-        gcloud --quiet auth login
-
     # Deploy App to App Engine
     - name: Deploy
       run: |


### PR DESCRIPTION
* Seems like the login run was unnecessary, likely a formatting issue with the YML that fixed the issue of credentials not being inited on the GoogleButt setup step